### PR TITLE
test: improve OrderController test coverage and include customerId in response

### DIFF
--- a/src/main/java/tech/wvs/desafiobtg/controller/OrderController.java
+++ b/src/main/java/tech/wvs/desafiobtg/controller/OrderController.java
@@ -1,5 +1,6 @@
 package tech.wvs.desafiobtg.controller;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,7 +27,7 @@ public class OrderController {
     public ResponseEntity<ApiResponse<OrderResponse>> listOrders(@PathVariable("customerId") Long customerId,
                                                                  @RequestParam(value = "page", defaultValue = "0") Integer page,
                                                                  @RequestParam(value = "pageSize", defaultValue = "5") Integer pageSize) {
-        var response = orderService.findById(customerId, page, pageSize);
+        var response = orderService.findById(customerId, PageRequest.of(page, pageSize));
         var totalOnOrders = orderService.findTotalOnOrdersByCustomerId(customerId);
 
         return ResponseEntity.ok(new ApiResponse<>(

--- a/src/main/java/tech/wvs/desafiobtg/controller/dto/OrderResponse.java
+++ b/src/main/java/tech/wvs/desafiobtg/controller/dto/OrderResponse.java
@@ -3,5 +3,6 @@ package tech.wvs.desafiobtg.controller.dto;
 import java.math.BigDecimal;
 
 public record OrderResponse(Long orderId,
+                            Long customerId,
                             BigDecimal total) {
 }

--- a/src/main/java/tech/wvs/desafiobtg/service/OrderService.java
+++ b/src/main/java/tech/wvs/desafiobtg/service/OrderService.java
@@ -54,11 +54,9 @@ public class OrderService {
                 .toList();
     }
 
-    public Page<OrderResponse> findById(Long customerId, Integer page, Integer pageSize) {
-        var pageRequest = PageRequest.of(page, pageSize);
-
+    public Page<OrderResponse> findById(Long customerId, PageRequest pageRequest) {
         return repository.findAllByCustomerId(customerId, pageRequest)
-                .map(order -> new OrderResponse(order.getOrderId(), order.getTotal()));
+                .map(order -> new OrderResponse(order.getOrderId(), order.getCustomerId(), order.getTotal()));
     }
 
     public BigDecimal findTotalOnOrdersByCustomerId(Long customerId) {

--- a/src/test/java/tech/wvs/desafiobtg/controller/OrderControllerTest.java
+++ b/src/test/java/tech/wvs/desafiobtg/controller/OrderControllerTest.java
@@ -18,6 +18,7 @@ import tech.wvs.desafiobtg.service.OrderService;
 import java.math.BigDecimal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
@@ -90,6 +91,40 @@ class OrderControllerTest {
 
         @Test
         void shouldReturnResponseBodyCorrectly() {
+            // Arrange
+            var customerId = 1L;
+            var page = 0;
+            var pageSize = 5;
+            var totalOnOrders = BigDecimal.valueOf(20.50);
+            var pagination = OrderResponseFactory.buildWithOneItem();
+
+            doReturn(pagination)
+                    .when(orderService).findById(anyLong(), any());
+
+            doReturn(totalOnOrders)
+                    .when(orderService).findTotalOnOrdersByCustomerId(anyLong());
+
+            // Act
+            var response = orderController.listOrders(customerId, page, pageSize);
+
+            // Assert
+            assertNotNull(response);
+            assertNotNull(response.getBody());
+            assertNotNull(response.getBody().data());
+            assertNotNull(response.getBody().paginationResponse());
+            assertNotNull(response.getBody().summary());
+
+
+            assertEquals(totalOnOrders, response.getBody().summary().get("totalOnOrders"));
+
+            assertEquals(pagination.getTotalElements(), response.getBody().paginationResponse().totalOrders());
+            assertEquals(pagination.getTotalPages(), response.getBody().paginationResponse().totalPages());
+            assertEquals(pagination.getNumber(), response.getBody().paginationResponse().page());
+            assertEquals(pagination.getSize(), response.getBody().paginationResponse().pageSize());
+
+            assertEquals(pagination.getContent(), response.getBody().data());
+
+
         }
     }
 }

--- a/src/test/java/tech/wvs/desafiobtg/controller/OrderControllerTest.java
+++ b/src/test/java/tech/wvs/desafiobtg/controller/OrderControllerTest.java
@@ -1,0 +1,63 @@
+package tech.wvs.desafiobtg.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import tech.wvs.desafiobtg.factory.OrderResponseFactory;
+import tech.wvs.desafiobtg.service.OrderService;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class OrderControllerTest {
+
+    @Mock
+    OrderService orderService;
+
+    @InjectMocks
+    OrderController orderController;
+
+
+    @Nested
+    class listOrders {
+        @Test
+        @DisplayName("Should return HttpStatus OK")
+        void shouldReturnHttpOk() {
+            // Arrange
+            var customerId = 1L;
+            var page = 0;
+            var pageSize = 5;
+
+            doReturn(OrderResponseFactory.buildWithOneItem())
+                    .when(orderService).findById(anyLong(), any());
+
+            doReturn(BigDecimal.valueOf(20.50))
+                    .when(orderService).findTotalOnOrdersByCustomerId(anyLong());
+
+            // Act
+            var response = orderController.listOrders(customerId, page, pageSize);
+
+            // Assert
+            assertEquals(HttpStatus.valueOf(200), response.getStatusCode());
+        }
+
+
+        @Test
+        void shouldPassCorrectParameterToService() {
+        }
+
+        @Test
+        void shouldReturnResponseBodyCorrectly() {
+        }
+    }
+}

--- a/src/test/java/tech/wvs/desafiobtg/controller/OrderControllerTest.java
+++ b/src/test/java/tech/wvs/desafiobtg/controller/OrderControllerTest.java
@@ -4,10 +4,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
+import tech.wvs.desafiobtg.controller.dto.OrderResponse;
 import tech.wvs.desafiobtg.factory.OrderResponseFactory;
 import tech.wvs.desafiobtg.service.OrderService;
 
@@ -27,6 +31,11 @@ class OrderControllerTest {
     @InjectMocks
     OrderController orderController;
 
+    @Captor
+    ArgumentCaptor<Long> customerIdCaptor;
+
+    @Captor
+    ArgumentCaptor<PageRequest> pageRequestCaptor;
 
     @Nested
     class listOrders {
@@ -53,7 +62,30 @@ class OrderControllerTest {
 
 
         @Test
+        @DisplayName("Should pass correct parameters to service")
         void shouldPassCorrectParameterToService() {
+            // Arrange
+            var customerId = 1L;
+            var page = 0;
+            var pageSize = 5;
+
+            //mockando o comportamento do metodo findById da service
+            doReturn(OrderResponseFactory.buildWithOneItem())
+                    .when(orderService).findById(customerIdCaptor.capture(), pageRequestCaptor.capture());
+
+            //mockando o comportamento do metodo findTotalOnOrdersByCustomerId da service
+            doReturn(BigDecimal.valueOf(20.50))
+                    .when(orderService).findTotalOnOrdersByCustomerId(customerIdCaptor.capture());
+
+            // Act
+            var response = orderController.listOrders(customerId, page, pageSize);
+
+            // Assert
+            assertEquals(2, customerIdCaptor.getAllValues().size());
+            assertEquals(customerId, customerIdCaptor.getAllValues().get(0));
+            assertEquals(customerId, customerIdCaptor.getAllValues().get(1));
+            assertEquals(page, pageRequestCaptor.getValue().getPageNumber());
+            assertEquals(pageSize, pageRequestCaptor.getValue().getPageSize());
         }
 
         @Test

--- a/src/test/java/tech/wvs/desafiobtg/factory/OrderResponseFactory.java
+++ b/src/test/java/tech/wvs/desafiobtg/factory/OrderResponseFactory.java
@@ -1,0 +1,17 @@
+package tech.wvs.desafiobtg.factory;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import tech.wvs.desafiobtg.controller.dto.OrderResponse;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class OrderResponseFactory {
+
+    public static Page<OrderResponse> buildWithOneItem() {
+        var orderResponse = new OrderResponse(1L, 2L, BigDecimal.valueOf(20.50));
+
+        return new PageImpl<>(List.of(orderResponse));
+    }
+}


### PR DESCRIPTION
Este PR tem como foco principal o aprimoramento da cobertura de testes no módulo de pedidos, com uma pequena refatoração para melhorar a resposta da API:

Adição de testes unitários para OrderController e OrderResponseFactory.

Verificação de parâmetros e respostas no método listOrders, incluindo checagens de nulidade e asserções detalhadas.

Refatoração leve no OrderService e OrderResponse para incluir o campo customerId.